### PR TITLE
Replace images for China accessibility

### DIFF
--- a/intro-site/src/main/resources/templates/interests.html
+++ b/intro-site/src/main/resources/templates/interests.html
@@ -10,11 +10,11 @@
 				<article class="card">
 					<h2>动漫</h2>
 					<figure class="figure">
-						<img src="https://source.unsplash.com/800x600/?manga,anime&sig=1" alt="天元突破 红莲螺岩" loading="lazy" />
+						<img th:src="@{/assets/anime/gurren-lagann.svg}" src="/assets/anime/gurren-lagann.svg" alt="天元突破 红莲螺岩" loading="lazy" />
 						<figcaption>天元突破 红莲螺岩</figcaption>
 					</figure>
 					<figure class="figure">
-						<img src="https://source.unsplash.com/800x600/?manga,anime&sig=2" alt="魔法少女小圆" loading="lazy" />
+						<img th:src="@{/assets/anime/madoka-magica.svg}" src="/assets/anime/madoka-magica.svg" alt="魔法少女小圆" loading="lazy" />
 						<figcaption>魔法少女小圆</figcaption>
 					</figure>
 					<ul class="links">
@@ -29,15 +29,15 @@
 					<h2>游戏</h2>
 					<div class="grid grid-3">
 						<figure class="figure">
-							<img src="https://source.unsplash.com/800x600/?video-game,controller&sig=1" alt="CRPG" loading="lazy" />
+							<img th:src="@{/assets/games/crpg.svg}" src="/assets/games/crpg.svg" alt="CRPG" loading="lazy" />
 							<figcaption>CRPG</figcaption>
 						</figure>
 						<figure class="figure">
-							<img src="https://source.unsplash.com/800x600/?video-game,controller&sig=2" alt="ARPG" loading="lazy" />
+							<img th:src="@{/assets/games/arpg.svg}" src="/assets/games/arpg.svg" alt="ARPG" loading="lazy" />
 							<figcaption>ARPG</figcaption>
 						</figure>
 						<figure class="figure">
-							<img src="https://source.unsplash.com/800x600/?open-world,landscape,game&sig=3" alt="开放世界" loading="lazy" />
+							<img th:src="@{/assets/games/open-world.svg}" src="/assets/games/open-world.svg" alt="开放世界" loading="lazy" />
 							<figcaption>开放世界</figcaption>
 						</figure>
 					</div>
@@ -51,7 +51,7 @@
 				<article class="card">
 					<h2>书籍</h2>
 					<figure class="figure">
-						<img src="https://source.unsplash.com/800x600/?books,library&sig=1" alt="书籍" loading="lazy" />
+						<img th:src="@{/assets/books/books.svg}" src="/assets/books/books.svg" alt="书籍" loading="lazy" />
 						<figcaption>书籍</figcaption>
 					</figure>
 					<ul class="links">
@@ -63,11 +63,11 @@
 					<h2>宠物（孔雀鱼）</h2>
 					<div class="grid grid-2">
 						<figure class="figure">
-							<img src="https://source.unsplash.com/800x600/?guppy,fish,aquarium&sig=1" alt="孔雀鱼 1" loading="lazy" />
+							<img th:src="@{/assets/pets/guppy-1.svg}" src="/assets/pets/guppy-1.svg" alt="孔雀鱼 1" loading="lazy" />
 							<figcaption>孔雀鱼 1</figcaption>
 						</figure>
 						<figure class="figure">
-							<img src="https://source.unsplash.com/800x600/?guppy,fish,aquarium&sig=2" alt="孔雀鱼 2" loading="lazy" />
+							<img th:src="@{/assets/pets/guppy-2.svg}" src="/assets/pets/guppy-2.svg" alt="孔雀鱼 2" loading="lazy" />
 							<figcaption>孔雀鱼 2</figcaption>
 						</figure>
 					</div>


### PR DESCRIPTION
Replace Unsplash image URLs with local assets to ensure images are viewable in China.

---
<a href="https://cursor.com/background-agent?bcId=bc-87f1d98b-f3f9-4df5-9ef0-f549475c0509">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87f1d98b-f3f9-4df5-9ef0-f549475c0509">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

