### PR TITLE
Embed custom image into file

### DIFF
--- a/intro-site/src/main/resources/templates/interests.html
+++ b/intro-site/src/main/resources/templates/interests.html
@@ -10,11 +10,11 @@
 				<article class="card">
 					<h2>动漫</h2>
 					<figure class="figure">
-						<img src="https://source.unsplash.com/800x600/?manga,anime&sig=1" alt="天元突破 红莲螺岩" loading="lazy" />
+						<img th:src="@{/images/interests/anime-1.jpg}" src="/assets/anime/gurren-lagann.svg" alt="天元突破 红莲螺岩" loading="lazy" onerror="this.onerror=null;this.src='/assets/anime/gurren-lagann.svg'" />
 						<figcaption>天元突破 红莲螺岩</figcaption>
 					</figure>
 					<figure class="figure">
-						<img src="https://source.unsplash.com/800x600/?manga,anime&sig=2" alt="魔法少女小圆" loading="lazy" />
+						<img th:src="@{/images/interests/anime-2.jpg}" src="/assets/anime/madoka-magica.svg" alt="魔法少女小圆" loading="lazy" onerror="this.onerror=null;this.src='/assets/anime/madoka-magica.svg'" />
 						<figcaption>魔法少女小圆</figcaption>
 					</figure>
 					<ul class="links">
@@ -29,15 +29,15 @@
 					<h2>游戏</h2>
 					<div class="grid grid-3">
 						<figure class="figure">
-							<img src="https://source.unsplash.com/800x600/?video-game,controller&sig=1" alt="CRPG" loading="lazy" />
+							<img th:src="@{/images/interests/game-crpg.jpg}" src="/assets/games/crpg.svg" alt="CRPG" loading="lazy" onerror="this.onerror=null;this.src='/assets/games/crpg.svg'" />
 							<figcaption>CRPG</figcaption>
 						</figure>
 						<figure class="figure">
-							<img src="https://source.unsplash.com/800x600/?video-game,controller&sig=2" alt="ARPG" loading="lazy" />
+							<img th:src="@{/images/interests/game-arpg.jpg}" src="/assets/games/arpg.svg" alt="ARPG" loading="lazy" onerror="this.onerror=null;this.src='/assets/games/arpg.svg'" />
 							<figcaption>ARPG</figcaption>
 						</figure>
 						<figure class="figure">
-							<img src="https://source.unsplash.com/800x600/?open-world,landscape,game&sig=3" alt="开放世界" loading="lazy" />
+							<img th:src="@{/images/interests/game-open-world.jpg}" src="/assets/games/open-world.svg" alt="开放世界" loading="lazy" onerror="this.onerror=null;this.src='/assets/games/open-world.svg'" />
 							<figcaption>开放世界</figcaption>
 						</figure>
 					</div>
@@ -51,7 +51,7 @@
 				<article class="card">
 					<h2>书籍</h2>
 					<figure class="figure">
-						<img src="https://source.unsplash.com/800x600/?books,library&sig=1" alt="书籍" loading="lazy" />
+						<img th:src="@{/images/interests/books.jpg}" src="/assets/books/books.svg" alt="书籍" loading="lazy" onerror="this.onerror=null;this.src='/assets/books/books.svg'" />
 						<figcaption>书籍</figcaption>
 					</figure>
 					<ul class="links">
@@ -63,11 +63,11 @@
 					<h2>宠物（孔雀鱼）</h2>
 					<div class="grid grid-2">
 						<figure class="figure">
-							<img src="https://source.unsplash.com/800x600/?guppy,fish,aquarium&sig=1" alt="孔雀鱼 1" loading="lazy" />
+							<img th:src="@{/images/interests/guppy-1.jpg}" src="/assets/pets/guppy-1.svg" alt="孔雀鱼 1" loading="lazy" onerror="this.onerror=null;this.src='/assets/pets/guppy-1.svg'" />
 							<figcaption>孔雀鱼 1</figcaption>
 						</figure>
 						<figure class="figure">
-							<img src="https://source.unsplash.com/800x600/?guppy,fish,aquarium&sig=2" alt="孔雀鱼 2" loading="lazy" />
+							<img th:src="@{/images/interests/guppy-2.jpg}" src="/assets/pets/guppy-2.svg" alt="孔雀鱼 2" loading="lazy" onerror="this.onerror=null;this.src='/assets/pets/guppy-2.svg'" />
 							<figcaption>孔雀鱼 2</figcaption>
 						</figure>
 					</div>


### PR DESCRIPTION
Switch `/interests` page to use local images with SVG fallbacks instead of Unsplash.

The user requested to display their own images on the `/interests` page. This PR sets up a static directory for user-provided images and updates the `interests.html` template to reference these local files. An `onerror` fallback is added to gracefully display existing SVG icons if a local image is not found.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a480f17-b859-4e6d-8814-386b956a59a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1a480f17-b859-4e6d-8814-386b956a59a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

